### PR TITLE
fix: add breakpoint to padding for better card view

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -106,7 +106,7 @@ const entries: CardProps[] = [
 
   <body>
     <div
-      class="grid grid-cols-12 grid-flow-col gap-x-5 gap-y-8 px-32 py-8 justify-evenly h-[95vh]"
+      class="grid grid-cols-12 grid-flow-col gap-x-5 gap-y-8 md:px-32 py-8 justify-evenly h-[95vh]"
     >
       <div class="hidden xl:block grid-start-1">
         <img class="w-max" src="/assets/image-1.png" />


### PR DESCRIPTION
To make UX in mobile better, I decided to add breakpoint to padding.

### Before

![image](https://user-images.githubusercontent.com/30806319/197220863-3e512212-a22e-4384-88c1-c15c882ae7e3.png)

### After

<img width="322" alt="image" src="https://user-images.githubusercontent.com/30806319/197220733-884b900a-2bc8-4ac1-916c-cc450d4a904e.png">


<!--- **Always tag `🚀 READY FOR REVIEW` once your PR is Ready to be one of us :)**

We value your endeavors to enhance the Hacktoberfest Museum better!

## If (this.PR.category === "The new entry 💫")

**Please tag `The new entry 💫` to the PR in order to categorize yours as the star being recognized by the Museum.**

## Else if (this.PR.category === "Enhancement 🛠")

**Please tag `Enhancement 🛠` to the PR as you're developing the Museum more wonderfully!**

## Finally:

> 🪄 **DON'T FORGET TO CLAIM YOUR TICKET!** via [Eventpop application form.](https://www.eventpop.me/events/13854/application_forms/845/applicants/new) -->