### PR TITLE
fix: hide scrollbar on windows

### DIFF
--- a/src/style/root.css
+++ b/src/style/root.css
@@ -11,3 +11,7 @@ body {
   height: 100vh;
   @apply bg-cover bg-center;
 }
+
+::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
Look like scroll bars do not exist on your device but mine do :joy:

![image](https://user-images.githubusercontent.com/59821765/197349188-4dc3f752-2705-4cb1-b4a7-785c3a68c3aa.png)

This PR fixes it.

![image](https://user-images.githubusercontent.com/59821765/197349208-3a30e15d-4ce0-4dc4-954b-ce998adb5c10.png)
